### PR TITLE
Bugfix: Change Gradle Wrapper Permissions in CI Workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-          cache: maven
+          cache: gradle
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,5 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
+      - name: Change wrapper permissions
+        run: chmod +x ./gradlew
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,9 +16,19 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
+        
       - name: Change wrapper permissions
         run: chmod +x ./gradlew
+        
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
Changes:
- Adds a step which changes the Gradle wrapper permissions before executing the build
- Adds a step which sets up Java version 21 (minimum version 17 required) with gradle caching