### PR TITLE
Bugfix: Validate search string is not blank

### DIFF
--- a/app/src/main/java/com/example/cardboardcompanion/viewmodel/CollectionViewModel.kt
+++ b/app/src/main/java/com/example/cardboardcompanion/viewmodel/CollectionViewModel.kt
@@ -55,7 +55,7 @@ class CollectionViewModel : ViewModel() {
     }
 
     private fun searchCollection(searchString: String) {
-        visibleCards = if (searchString.isNotEmpty()) {
+        visibleCards = if (searchString.isNotBlank()) {
             isActiveSearch = true
             cardCollection.collection.filter {
                 it.name.contains(searchString, ignoreCase = true)


### PR DESCRIPTION
Bug:
Before performing a search, the search string should be checked to make sure it is not blank. Currently, the check only makes sure the string is not empty.

Changes:
- Checks for a blank search string before executing a search, to avoid performing unnecessary processing