### PR TITLE
QOL Improvement: Display number of search results

### DIFF
--- a/app/src/main/java/com/example/cardboardcompanion/ui/screen/CollectionScreen.kt
+++ b/app/src/main/java/com/example/cardboardcompanion/ui/screen/CollectionScreen.kt
@@ -123,7 +123,7 @@ private fun CollectionScreen(
                 Spacer(modifier = Modifier.weight(1f))
             } else {
                 Text(
-                    "Displaying results for: $searchParam",
+                    "Found ${cards.size} results for: $searchParam",
                     fontStyle = FontStyle.Italic,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier


### PR DESCRIPTION
Current behavior:
- Upon executing a search of the collection, the search term will be displayed alongside the matching cards

Desired behavior:
- Upon executing a search of the collection, the number of search results and the search term will be displayed alongside the matching cards